### PR TITLE
top5 for each news category in newsController

### DIFF
--- a/server/controllers/newsController.js
+++ b/server/controllers/newsController.js
@@ -7,43 +7,26 @@ const API_KEY = process.env.NEWS_API_KEY;
 const CATEGORIES = ['business', 'entertainment', 'general', 'health', 'science', 'sports', 'technology'];
 
 // get information from google maps api
-newsController.getNews = (req, res, next) => {
+newsController.getNews = async (req, res, next) => {
   const { countrycode } = req.params;
-  const url = `https://newsapi.org/v2/top-headlines?country=${countrycode}&category=${CATEGORIES[1]}&pageSize=5&page=1&apiKey=${API_KEY}`;
-
-  fetch(url)
-    .then((data) => data.json())
-    .then(results => {
-      res.locals.news = results.articles;
-      return next();
-    })
-    .catch((error) => next({ log: `Error in newsController.getNews; ERROR: ${error}` }));
-
-  // TODO: make promiseAll work so that we fetch a request per news category and get 5 articles per.
-  /*
   const promises = [];
-  iterate through each element in CATEGORIES
-  for (let i = 0; i < CATEGORIES.length; i += 1) {
-    const categoryName = CATEGORIES[i];
-    const url = `https://newsapi.org/v2/top-headlines?country=${countrycode}&category=${categoryName}&pageSize=5&page=1&apiKey=${API_KEY}`;
-    console.log('in news.js', 'url: ', url);
-    promises.push(fetch(url));
-  }
+  res.locals.news = {};
 
-  Promise.all(promises)
-    .then((resultsArr) => {
-      console.log(`resultsArr: ${JSON.stringify(resultsArr)}`);
-      // iterate over resultsArray
-      // store data in res.locals.news.<category_name>
-      resultsArr.forEach((newResultObj, index) => {
-        console.log(`newResultObj.articles: ${newResultObj.articles}`);
+  // store fetch request promise for each CATEGORIES element
+  CATEGORIES.forEach((categoryName) => {
+    const url = `https://newsapi.org/v2/top-headlines?country=${countrycode}&category=${categoryName}&pageSize=5&page=1&apiKey=${API_KEY}`;
+    promises.push(fetch(url).then((data) => data.json()));
+  });
+
+  // wait for all promises in promises array have resolved
+  await Promise.all(promises)
+    .then((results) => {
+      results.forEach((newResultObj, index) => {
         res.locals.news[CATEGORIES[index]] = newResultObj.articles;
       });
-      return next();
     })
     .catch((error) => next({ log: `Error in newsController.getNews; ERROR: ${error}` }));
-
-    */
+  return next();
 };
 
 module.exports = newsController;


### PR DESCRIPTION
Updated the newsController to be async, store a promise for each fetch request on each news category, then send new object with 5 articles per following categories:
['business', 'entertainment', 'general', 'health', 'science', 'sports', 'technology']